### PR TITLE
Fix return type on Apple `userByIdentityToken()`

### DIFF
--- a/src/Apple/Provider.php
+++ b/src/Apple/Provider.php
@@ -117,7 +117,7 @@ class Provider extends AbstractProvider
      *
      * @return User $user
      */
-    public function userByIdentityToken(string $token): SocialiteUser
+    public function userByIdentityToken(string $token): User
     {
         $array = $this->getUserByToken($token);
 


### PR DESCRIPTION
This PR fixes the return type for Apple on the `userByIdentityToken()` method. 

`User` is already imported here:

https://github.com/ahinkle/Providers/blob/c08d20243e483f6bcb77d89d3106f5fa1f081d27/src/Apple/Provider.php#L20-L22

![Screenshot 2023-05-23 at 2 45 45 PM](https://github.com/ahinkle/Providers/assets/17038330/5f1ea64e-b18f-4b5e-a9cf-b297a2598a2c)


TypeError SocialiteProviders\Apple\Provider::userByIdentityToken(): Return value must be of type SocialiteProviders\Apple\SocialiteUser, SocialiteProviders\Manager\OAuth2\User returned

```
  at vendor/socialiteproviders/apple/Provider.php:134
    130▕     public function userByIdentityToken(string $token): SocialiteUser
    131▕     {
    132▕         $array = $this->getUserByToken($token);
    133▕ 
  ➜ 134▕         return $this->mapUserToObject($array);
    135▕     }
    136▕ 
    137▕     /**
    138▕      * Verify Apple jwt.
```